### PR TITLE
Show meaningful error when encountering garbage at start of log file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -736,7 +736,14 @@ impl RKD
 
 		'line_parser: for line in log 
 		{
-			let parsed = LogLine::parse(&line,ambiguousFileCount,side).unwrap().1;
+			let parsed = match LogLine::parse(&line,ambiguousFileCount,side) {
+				Ok(result) => result,
+				Err(e) => {
+					eprintln!("Error: Failed to parse log line: '{}'", line);
+					eprintln!("Expected format: <size>  <md5hash>  <filepath>");
+					panic!("Parsing error: {}", e);
+				}
+			}.1;
 
 			if parsed.is_none() {continue;}
 


### PR DESCRIPTION
Passing the wrong file format to rkd results in a panic with no explanation. This shows the actual error.

It's a minimal patch. This should really bubble up Error/Result to main and exit with the right error code rather than panicking, but having had a go that will be a bit of work, and it'd be good to get the format/clippy PRs in first #5 #6

There are no tests for this, not sure if you care or if it's worth it for the error cases

## Before

```
╭─tim@fox ~/repo/rkd ‹dev› 
╰─$ cargo run -- ~/Documents/hashdeep-checksums.txt ~/Documents/backups/disk-hog-backup-hashes.md5
...
thread 'main' panicked at src/main.rs:739:72:
called `Result::unwrap()` on an `Err` value: Error(Error { input: "%%%% HASHDEEP-1.0", code: Digit })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## After

```
╭─tim@fox ~/repo/rkd ‹better-parse-error› 
╰─$ cargo run -- ~/Documents/hashdeep-checksums.txt ~/Documents/backups/disk-hog-backup-hashes.md5
...
Error: Failed to parse log line: '%%%% HASHDEEP-1.0'
Expected format: <size>  <md5hash>  <filepath>

thread 'main' panicked at src/main.rs:744:21:
Parsing error: Parsing Error: Error { input: "%%%% HASHDEEP-1.0", code: Digit }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

(yes I know hashdeep isn't supported, but it was worth a try)